### PR TITLE
urlset增加协议版本描述

### DIFF
--- a/Action.php
+++ b/Action.php
@@ -121,7 +121,7 @@ class BaiduSubmit_Action extends Typecho_Widget implements Widget_Interface_Do
         //priority -> 0.0优先级最低、1.0最高
         header("Content-Type: application/xml");
         echo "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n";
-        echo "<urlset>\n";
+        echo "<urlset xmlns='http://www.sitemaps.org/schemas/sitemap/0.9'>\n";
         foreach ($pages AS $page) {
             $type = $page['type'];
             $routeExists = (NULL != Typecho_Router::get($type));


### PR DESCRIPTION
在Google  Search Console中提交sitemap时报错xmlns格式不正确，需要加上版本描述，增加`xmlns='http://www.sitemaps.org/schemas/sitemap/0.9'`后提交成功。这个xmlns是标准站点地图协议要求的，参见[Sitemaps XML format](http://www.sitemaps.org/protocol.html)；另外百度在详细的sitemap格式示例中也有这段代码，参见[平台工具使用帮助](http://zhanzhang.baidu.com/college/courseinfo?id=267&page=2#h2_article_title1)。
